### PR TITLE
Changed variable names for excerpts in blog.

### DIFF
--- a/content/blog/Data_Mining_Course_of_Economics_Moscow.md
+++ b/content/blog/Data_Mining_Course_of_Economics_Moscow.md
@@ -1,21 +1,30 @@
 +++
 showonlyimage = false
 draft = false
+hardLineBreak = true 
+joinLines = false
+type = "blog"
+
+# Date format is YYYY-MM-DD.
 date = "2017-09-07"
+categories = ["data mining", "HSE", "python","workshop"]
+author = "Janez Novak"
 title = "Data Mining Course at Higher School of Economics, Moscow"
 weight = 15
-#  Size of frontPageImage:  width: 300px , height: 170px 
-frontPageImage = "/blog_img/front_page_data_mining_for_economists.jpg"
+
 image = "/blog_img/moscow-1.jpg"
-#  Size of thumbImage:  width: 450px , height: 300px 
+
+#  Size of frontPageImage:  width: 300px, height: 170px. 
+frontPageImage = "/blog_img/front_page_data_mining_for_economists.jpg"
+
+#  Size of thumbImage:  width: 450px, height: 300px. 
 thumbImage = "/blog_img/moscow-thumb.png"
-type = "blog"
-categories = ["data mining", "HSE", "python","workshop"]
-hardLineBreak = true 
-author = "Janez Novak"
-joinLines = false
-excerpt = ""
-frontPageText = 'Janez and I have recently returned from a two-week stay in Moscow, Russian Federation, where we were teaching data mining to MA students of Applied Statistics.'
+
+#Short excerpt will be shown on the home page. Limit text to 140 characters.
+shortExcerpt = "Janez and I have recently returned from a two-week stay in Moscow, Russian Federation, where we were teaching data mining to MA students of Applied Statistics."
+
+# Long excerpt will be shown on the blog page. Limit text to 280 characters.
+longExcerpt = ""
 
 +++
 

--- a/content/blog/Data_Mining_and_Machine_Learning_for_Economists.md
+++ b/content/blog/Data_Mining_and_Machine_Learning_for_Economists.md
@@ -1,15 +1,30 @@
 +++
+showonlyimage = false
 draft = false
+hardLineBreak = true 
+joinLines = false
 type = "blog"
-image = "/blog_img/IMG_20180713_092503.jpg"
-thumbImage = "/blog_img/Data_Mining_and_Machine_Learning_for_Economists-thumb.png"
+
+# Date format is YYYY-MM-DD.
 date = "2013-05-05"
+categories = ["clustering", "data mining", "summer school"]
+author = "Janez Novak"
 title = "Data Mining and Machine Learning for Economists"
 weight = 15
-hardLineBreak = true 
-categories = ["clustering", "data mining", "summer school"]
-excerpt = ""
-joinLines = false
+
+image = "/blog_img/IMG_20180713_092503.jpg"
+
+#  Size of frontPageImage:  width: 300px, height: 170px. 
+frontPageImage = ""
+
+#  Size of thumbImage:  width: 450px, height: 300px. 
+thumbImage = "/blog_img/Data_Mining_and_Machine_Learning_for_Economists-thumb.png"
+
+#Short excerpt will be shown on the home page. Limit text to 140 characters.
+shortExcerpt = ""
+
+# Long excerpt will be shown on the blog page. Limit text to 280 characters.
+longExcerpt = ""
 +++
 
 Last week Blaž, Marko and I held a week long introductory Data Mining and Machine Learning course at the Ljubljana Doctoral Summer School 2018. We got a room full of dedicated students and we embarked on a journey through standard and advanced machine learning techniques, all presented of course in Orange.

--- a/content/blog/Orange_with_Spectroscopy_Add-on_Workshop.md
+++ b/content/blog/Orange_with_Spectroscopy_Add-on_Workshop.md
@@ -1,17 +1,31 @@
 +++
+showonlyimage = false
 draft = false
-date = "2016-02-05"
+hardLineBreak = true 
+joinLines = false
 type = "blog"
+
+# Date format is YYYY-MM-DD. 
+date = "2016-02-05"
+categories = ["infraorange", "spectral orange", "workshop"]
+author = "Janez Novak"
 title = "Orange with Spectroscopy Add-on Workshop"
 weight = 15
+
 image = "/blog_img/Orange_with_Spectroscopy_Add-on_Workshop-1.jpg"
-#  Size of thumbImage:  width: 450px , height: 300px 
+
+#  Size of frontPageImage:  width: 300px, height: 170px. 
+frontPageImage = ""
+
+#  Size of thumbImage:  width: 450px, height: 300px .
 thumbImage = "/blog_img/Orange_with_Spectroscopy_Add-on_Workshop-thumb.png"
-categories = ["infraorange", "spectral orange", "workshop"]
-hardLineBreak = true 
-excerpt = ""
-joinLines = false
-frontPageText = "We have just concluded our enhanced Introduction to Data Science workshop, which included several workflows for spectroscopy analysis."
+
+#Short excerpt will be shown on the home page. Limit text to 140 characters.
+shortExcerpt = "We have just concluded our enhanced Introduction to Data Science workshop, which included several workflows for spectroscopy analysis."
+
+# Long excerpt will be shown on the blog page. Limit text to 280 characters.
+longExcerpt = ""
+
 +++
 
 

--- a/content/blog/Python_Script_Managing_Data_on_the_Fly.md
+++ b/content/blog/Python_Script_Managing_Data_on_the_Fly.md
@@ -1,19 +1,38 @@
 +++
+showonlyimage = false
 draft = false
-date = "2016-03-05"
-type= "blog"
-title = "Python Script: Managing Data on the Fly"
-weight = 15
 hardLineBreak = true 
-categories = ["Python", "Numpy"]
 joinLines = false
-excerpt = ""
-frontPageText = "Python Script is this mysterious widget most people don't know how to use, even those versed in Python. Python Script is the widget that supplements Orange functionalities with (almost) everything that Python can offer"
+type = "blog"
+
+# Date format is YYYY-MM-DD.
+date = "2016-03-05"
+categories = ["Python", "Numpy"]
+author = "Janez Novak"
+title = "Python Script: Managing Data on the Fly"
+weight = 15 
+
+image = "/blog_img/IMG_20180713_092503.jpg"
+
+#  Size of frontPageImage:  width: 300px, height: 170px. 
+frontPageImage = ""
+
+#  Size of thumbImage:  width: 450px, height: 300px. 
+thumbImage = "/blog_img/Data_Mining_and_Machine_Learning_for_Economists-thumb.png"
+
+#Short excerpt will be shown on the home page. Limit text to 140 characters.
+shortExcerpt = "Python Script is this mysterious widget most people don't know how to use, even those versed in Python. Python Script is the widget that supplements Orange functionalities with (almost) everything that Python can offer."
+
+# Long excerpt will be shown on the blog page. Limit text to 280 characters.
+longExcerpt = ""
+
 +++
 
 
-Python Script is this mysterious widget most people don't know how to use, even those versed in Python. Python Script is the widget that supplements Orange functionalities with (almost) everything that Python can offer. And it's time we unveil some of its functionalities with a simple example
+Python Script is this mysterious widget most people don't know how to use, even those versed in Python. Python Script is the widget that supplements Orange functionalities with (almost) everything that Python can offer.
 <!--more-->
+And it's time we unveil some of its functionalities with a simple example
+
 ### .Example: Batch Transform the Data
 
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -73,8 +73,8 @@
                      </div>
                      <div class='excerpt-content'>
                         <article>
-                           {{ if and (isset .Params "excerpt") .Params.excerpt }}
-                           {{ .Params.excerpt}}
+                           {{ if and (isset .Params "longExcerpt") .Params.longExcerpt }}
+                           {{ .Params.longExcerpt}}
                            {{else}}
                            {{ .Summary }}
                            {{end}}

--- a/layouts/home/list.html
+++ b/layouts/home/list.html
@@ -61,14 +61,12 @@
                            <a href="{{ .Permalink }} "> {{ .Title }} </a>
                         </h2>
                      </div>
-                     <div class='excerpt-content front-page-image'>
-                        <!-- {{.Params.frontPageText | markdownify}} -->
-                        
+                     <div class='excerpt-content front-page-image'>                        
                         <article style="padding-bottom: 20px;">
-                           {{ if .Params.frontPageText}}
-                           {{ .Params.frontPageText | markdownify}}
+                           {{ if .Params.shortExcerpt}}
+                           {{ .Params.shortExcerpt | markdownify}}
                            {{else}}
-                           {{ .Params.excerpt }}
+                           {{ .Params.longExcerpt }}
                            {{end}}
                            <a href="{{ .Permalink }} "> Read more </a>
                            


### PR DESCRIPTION
Variables `frontPageText` and `excerpt` are changed to `shortExcerpt` and `longExcerpt`. New variable names are included in templates. Comments added to a few variables in blog `.md` files with brief explanatory notes about its function.

Fixes #26 