### PR TITLE
Small fixes in footer.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -47,7 +47,7 @@
                             <ul class="links list-sitemap">
                                 <li><div class="sitemap-cat">Documentation</div></li>
                                 <li><a class="sitemap-sub" href='/{{"getting-started" | urlize}}/'>Get started</a></li>
-                                <!-- <li><a class="sitemap-sub" href="{% url 'toolbox' %}">Widgets</a></li> -->
+                                <li><a class="sitemap-sub" href="/{{"widget-catalog" | urlize}}/">Widgets</a></li>
                                 <li><a class="sitemap-sub" href="http://docs.orange.biolab.si/3/data-mining-library/">Scripting</a></li>
                             </ul>
                         </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -66,7 +66,7 @@
                 <div class="col-md-5 col-sm-12 col-xs-12 sitemap-group">
                     <div class="latest-blog-posts">
                         <ul class="links list-sitemap" style="padding-bottom: 10px">
-                            <li><b><a class="sitemap-cat" href="http://blog.biolab.si/">Latest blog posts</a></b></li>
+                            <li><b><a class="sitemap-cat" href="/blog/">Latest blog posts</a></b></li>
                             {{ range first 3 (where .Site.RegularPages.ByDate.Reverse "Section" "blog") }}
                             <li>
                             <div class="row">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,10 +29,10 @@
 
                             <ul class="links list-sitemap">
                                 <li><b><div class="sitemap-cat">Community</div></b></li>
-                                <li><a class="sitemap-sub" href="https://www.facebook.com/orangedm">Facebook</a></li>
-                                <li><a class="sitemap-sub" href="https://www.youtube.com/channel/UClKKWBe2SCAEyv7ZNGhIe4g">YouTube</a></li>
-                                <li><a class="sitemap-sub" href="https://twitter.com/orangedataminer">Twitter</a></li>
-                                <li><a class="sitemap-sub" href="https://datascience.stackexchange.com/questions/tagged/orange">Stack Exchange</a></li>
+                                <li><a class="sitemap-sub" href="https://www.facebook.com/orangedm" target="_blank">Facebook</a></li>
+                                <li><a class="sitemap-sub" href="https://www.youtube.com/channel/UC_kfdmdWIQDRrsMpUMf_pmA" target="_blank">YouTube</a></li>
+                                <li><a class="sitemap-sub" href="https://twitter.com/orangedataminer" target="_blank">Twitter</a></li>
+                                <li><a class="sitemap-sub" href="https://datascience.stackexchange.com/questions/tagged/orange" target="_blank">Stack Exchange</a></li>
                             </ul>
 
                         </div>
@@ -54,8 +54,8 @@
 
                         <div class="col-sm-3 sitemap-group">
                             <ul class="links list-sitemap">
-                                <li><b><div class="sitemap-cat" href="https://github.com/biolab/orange3">Developers</div></b></li>
-                                <li><a class="sitemap-sub" href="https://github.com/biolab/orange3">GitHub</a></li>
+                                <li><b><div class="sitemap-cat">Developers</div></b></li>
+                                <li><a class="sitemap-sub" href="https://github.com/biolab/orange3-single-cell" target="_blank">GitHub</a></li>
                                 <li><a class="sitemap-sub" href="/contribute/">Contribute</a></li>
                             </ul>
                         </div>


### PR DESCRIPTION
The latest blog posts link is changed from orange blog to scOrange blog.
Open footer external links in new window. 
Widget-catalog link added in the footer.

Fix #43, #42, #40 