### PR TITLE
Display in narrower windows fix.

### DIFF
--- a/layouts/home/list.html
+++ b/layouts/home/list.html
@@ -125,9 +125,9 @@
                 {{ end }}
             </div>
         </div>
-        <div class='content col-xs-12 feature-image {{if (eq .Params.thumbnailImagePosition "left") }}{{else }}panel-left{{ end }}'>
+        <div class='content col-md-6 col-xs-12 feature-image {{if (eq .Params.thumbnailImagePosition "left") }}{{else }}panel-left{{ end }}'>
             {{ if isset .Params "learnMore" }}<a href="{{ .Permalink }}">{{end}}
-                <img class='image {{.Params.thumbnailImagePosition}}' src="{{ .Params.thumbnailImage}}">
+                <img class='image {{.Params.thumbnailImagePosition}}' src="{{ .Params.image}}">
             {{ if isset .Params "learnMore" }}</a>{{end}}
         </div>
     </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3670,6 +3670,11 @@ li.pingback:first-child {
   transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s; 
 }
 
+@media (max-width: 991px) {
+    .feature-panel {
+        background: none !important;
+    }
+}
 
 /*
 ATTENTION:


### PR DESCRIPTION
Problem:
 - On a mobile device display of homepage is broken, images overlay text.

Solution:
 - Now images on mobile devices homepage render under the text.

Fixes: #31 
