### PR TITLE
Prepare scOrange release 1.3.0

### DIFF
--- a/layouts/download/list.html
+++ b/layouts/download/list.html
@@ -24,14 +24,14 @@
                 <div class="">
                     <div class="content">
                         <h2>Download the latest version for Windows</h2>
-                        <a id="recommended-download" style="margin-top: 10px" class="btn btn-warning big-button-base" onclick="windows()" href="https://service.biolab.si/download/singlecell?platform=win">
+                        <a id="recommended-download" style="margin-top: 10px" class="btn btn-warning big-button-base" onclick="windows()" href="https://download.biolab.si/download/files/scOrange-1.3.0-Miniconda-x86_64.exe">
                             Download scOrange {{ if and (isset .Params "version") .Params.version }}  
                             {{.Params.version}}
                             {{end}}
                         </a>
 
                         <h3><a id="standalone"></a>Standalone installer</h3>
-                        <a href="https://service.biolab.si/download/singlecell?platform=win">scOrange-win_amd64.exe (64 bit)</a><br />
+                        <a href="https://download.biolab.si/download/files/scOrange-1.3.0-Miniconda-x86_64.exe">scOrange-win_amd64.exe (64 bit)</a><br />
                         <p>Can be used without administrative priviledges.</p>
 
                     </div>
@@ -42,13 +42,13 @@
                  <div class="" >
                    <div class="content">
                         <h2>Download the latest version for Mac</h2>
-                        <a id="recommended-download" onclick="mac()"style="margin-top: 10px" class="btn btn-warning big-button-base" href="https://service.biolab.si/download/singlecell?platform=mac">
+                        <a id="recommended-download" onclick="mac()"style="margin-top: 10px" class="btn btn-warning big-button-base" href="https://download.biolab.si/download/files/scOrange-1.3.0.dmg">
                             Download scOrange {{ if and (isset .Params "version") .Params.version }}  
                             {{.Params.version}}
                             {{end}}
                         </a>
                         <h3><a id="standalone"></a>Bundle</h3>
-                        <a href="https://service.biolab.si/download/singlecell?platform=mac">scOrange.dmg</a><br/>
+                        <a href="https://download.biolab.si/download/files/scOrange-1.3.0.dmg">scOrange.dmg</a><br/>
                         <p>A universal bundle with everything packed in and ready to use.</p>
                     </div>
                 </div>


### PR DESCRIPTION
Release links are updated to bypass our service. This increases stability, but the links need to be updated at each release.